### PR TITLE
Dkt rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The users can also reprocess raw data using wrappers for FaFast and MNE-python (
 [![Waffle.io - Columns and their card count](https://badge.waffle.io/pelednoam/mmvt.svg?columns=all)](https://waffle.io/pelednoam/mmvt)
 
 ## Videos & Figures
-* The [aparc.DKTatlas40](https://surfer.nmr.mgh.harvard.edu/fswiki/CorticalParcellation) FreeSurfer atlas:
+* The [aparc.DKTatlas](https://surfer.nmr.mgh.harvard.edu/fswiki/CorticalParcellation) FreeSurfer atlas:
 ![Example](https://user-images.githubusercontent.com/1643819/39079174-8b61dc1a-44e3-11e8-8ce6-1c783596d1ae.png)
 
 <!--- * Spatial and temporal ttest result of MEG activation

--- a/resources/atlas.csv
+++ b/resources/atlas.csv
@@ -1,7 +1,7 @@
 name in blend file, annot name, description
 aparc, aparc, curvature.buckner40.filled.desikan_killiany
 aparc2009, aparc.a2009s, destrieux.simple.2009-07-28
-dkt, aparc.DKTatlas40, DKTatlas40 (https://surfer.nmr.mgh.harvard.edu/fswiki/CorticalParcellation)
+dkt, aparc.DKTatlas, DKTatlas (https://surfer.nmr.mgh.harvard.edu/fswiki/CorticalParcellation)
 laus125, laus125, Lausanne125 parcellation (http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0048121)
 laus250, laus250, Lausanne250 parcellation
 laus500, laus500, Lausanne500 parcellation

--- a/src/examples/morph_electrodes_to_template.py
+++ b/src/examples/morph_electrodes_to_template.py
@@ -348,7 +348,7 @@ def export_into_csv(template_system, mmvt_dir, prefix=''):
     print('export_into_csv: {}'.format(op.isfile(csv_fname) and op.isfile(csv_fname2)))
 
 
-def compare_electrodes_labeling(electrodes, template_system, atlas='aparc.DKTatlas40'):
+def compare_electrodes_labeling(electrodes, template_system, atlas='aparc.DKTatlas'):
     template = 'fsaverage' if template_system == 'ras' else 'colin27' if template_system == 'mni' else template_system
     template_elab_files = glob.glob(op.join(
         MMVT_DIR, template, 'electrodes', '{}_{}_electrodes_cigar_r_3_l_4.pkl'.format(template, atlas)))

--- a/src/examples/render_image.py
+++ b/src/examples/render_image.py
@@ -44,7 +44,7 @@ if __name__ == '__main__':
     from src.utils import args_utils as au
     parser = argparse.ArgumentParser(description='MMVT')
     parser.add_argument('-s', '--subject', help='subject name', required=True, type=au.str_arr_type)
-    parser.add_argument('-a', '--atlas', help='atlas name', required=False, default='aparc.DKTatlas40')
+    parser.add_argument('-a', '--atlas', help='atlas name', required=False, default='aparc.DKTatlas')
     parser.add_argument('-q', '--quality', help='quality', required=False, default=20, type=int)
     parser.add_argument('-f', '--function', help='function name', required=False, default='render_perspectives')
     args = utils.Bag(au.parse_parser(parser))

--- a/src/misc/electrodes_report.py
+++ b/src/misc/electrodes_report.py
@@ -89,7 +89,7 @@ def get_elec_group(elec_name, bipolar):
 if __name__ == '__main__':
     subject = 'mg96'
     bipolar = True
-    atlas = 'aparc.DKTatlas40'
+    atlas = 'aparc.DKTatlas'
     error_radius, elec_length = 3, 4
     good_channels = get_good_channels()
     groups_ordering = get_groups_ordering()

--- a/src/misc/labels_morphing_problem.py
+++ b/src/misc/labels_morphing_problem.py
@@ -132,7 +132,7 @@ def get_n_jobs(n_jobs):
 if __name__ == '__main__':
     subjects_dir = os.environ['SUBJECTS_DIR']
     subject = 'sample'
-    atlas = 'laus125' # 'aparc.DKTatlas40'
+    atlas = 'laus125' # 'aparc.DKTatlas'
     n_jobs = get_n_jobs(-1)
     morphed_labels = morph_labels_from_fsaverage(subject, subjects_dir, atlas=atlas, n_jobs=n_jobs)
     ret = labels_to_annot(subject, morphed_labels, subjects_dir, atlas, overwrite=True)

--- a/src/misc/reading_cinthya_data.py
+++ b/src/misc/reading_cinthya_data.py
@@ -44,15 +44,15 @@ def ttest(data, root_fol, output_name, two_tailed_test=True, alpha=0.05, is_grea
             welch_labels.append(label)
     title = output_name.replace('_', ' ')
     np.savez(op.join(root_fol, '{}_mean.npz'.format(output_name)), names=labels,
-             atlas='aparc.DKTatlas40', data=np.array(labels_means), title=title,
+             atlas='aparc.DKTatlas', data=np.array(labels_means), title=title,
              data_min=np.min(labels_means), data_max=np.max(labels_means), cmap='YlOrRd')
     print('{} ttest: {} significant labels were found'.format(title, len(ttest_stats)))
     print('{} welch: {} significant labels were found'.format(title, len(ttest_stats)))
     np.savez(op.join(root_fol, '{}_ttest.npz'.format(output_name)), names=np.array(ttest_labels),
-             atlas='aparc.DKTatlas40', data=np.array(ttest_stats), title='{} ttest'.format(title),
+             atlas='aparc.DKTatlas', data=np.array(ttest_stats), title='{} ttest'.format(title),
              data_min=0, data_max=0.05, cmap='RdOrYl')
     np.savez(op.join(root_fol, '{}_welch.npz'.format(output_name)), names=np.array(welch_labels),
-             atlas='aparc.DKTatlas40', data=np.array(welch_stats), title='{} welch'.format(title),
+             atlas='aparc.DKTatlas', data=np.array(welch_stats), title='{} welch'.format(title),
              data_min=0, data_max=0.05, cmap='RdOrYl')
     return ttest_stats, welch_stats
 

--- a/src/mmvt_addon/mmvt_utils.py
+++ b/src/mmvt_addon/mmvt_utils.py
@@ -2380,7 +2380,7 @@ def check_if_atlas_exist(labels_fol, atlas):
         len(glob.glob(op.join(labels_fol, atlas, '*.label'))) > 0
 
 
-def find_annot_labels(subjects_dir='', atlas='aparc.DKTatlas40'):
+def find_annot_labels(subjects_dir='', atlas='aparc.DKTatlas'):
     if subjects_dir == '':
         subjects_dir = get_link_dir(get_links_dir(), 'subjects')
     labels = []
@@ -2399,7 +2399,7 @@ def find_annot_labels(subjects_dir='', atlas='aparc.DKTatlas40'):
 
 def check_atlas_by_labels_names(labels_names):
     subjects_dir = get_link_dir(get_links_dir(), 'subjects')
-    for atlas in ['aparc.DKTatlas40', 'aparc', 'aparc.a2009s', 'aparc250', 'laus125', 'laus250', 'laus500']:
+    for atlas in ['aparc.DKTatlas', 'aparc', 'aparc.a2009s', 'aparc250', 'laus125', 'laus250', 'laus500']:
         atlas_labels = find_annot_labels(subjects_dir, atlas)
         atlas_labels_names = set([l.name for l in atlas_labels])
         if set(labels_names).issubset(atlas_labels_names):

--- a/src/mmvt_addon/scripts/scripts_utils.py
+++ b/src/mmvt_addon/scripts/scripts_utils.py
@@ -355,7 +355,7 @@ def add_default_args():
     parser.add_argument('-s', '--subject', help='subject name', required=False, default='')
     parser.add_argument('--subjects', help='subjects names', required=False, default='', type=au.str_arr_type)
     parser.add_argument('-a', '--atlas', help='atlas name', required=False, default='dkt')
-    parser.add_argument('--real_atlas', help='atlas name', required=False, default='aparc.DKTatlas40')
+    parser.add_argument('--real_atlas', help='atlas name', required=False, default='aparc.DKTatlas')
     parser.add_argument('-b', '--bipolar', help='bipolar', required=False, type=au.is_true)
     parser.add_argument('-d', '--debug', help='debug', required=False, default=0, type=au.is_true)
     parser.add_argument('--overwrite', help='overwrite', required=False, default=1, type=au.is_true)

--- a/src/preproc/anatomy.py
+++ b/src/preproc/anatomy.py
@@ -425,7 +425,7 @@ def create_annotation(subject, atlas='aparc250', fsaverage='fsaverage', remote_s
                 labels = []
             annot_ok = annot_ok and len(labels) > 1
         if annot_ok:
-            print('The annotation file is already exist ({})'.format(annotation_fname_template))
+            print('The annotation file already exists ({})'.format(annotation_fname_template))
             return True
 
     labels_files = glob.glob(op.join(SUBJECTS_DIR, subject, 'label', atlas, '*.label'))

--- a/src/preproc/anatomy.py
+++ b/src/preproc/anatomy.py
@@ -610,7 +610,7 @@ def create_spatial_connectivity(subject, surf_types=('pial', 'dural'), overwrite
     return ret
 
 
-def calc_three_rois_intersection(subject, rois, output_fol='', model_name='', atlas='aparc.DKTatlas40', debug=False,
+def calc_three_rois_intersection(subject, rois, output_fol='', model_name='', atlas='aparc.DKTatlas', debug=False,
                                  overwrite=False):
 
     def get_vertices_between_labels(label1_contours_verts_inds, label2_contours_verts_inds, vertices_neighbros):
@@ -672,7 +672,7 @@ def calc_three_rois_intersection(subject, rois, output_fol='', model_name='', at
     return intesection_points
 
 
-def calc_flat_patch_cut_vertices(subject, atlas='aparc.DKTatlas40', overwrite=True):
+def calc_flat_patch_cut_vertices(subject, atlas='aparc.DKTatlas', overwrite=True):
     output_fname = op.join(MMVT_DIR, subject, 'flat_patch_cut_vertices.pkl')
     if op.isfile(output_fname) and not overwrite:
         return True
@@ -1073,9 +1073,9 @@ def calc_3d_atlas(subject, atlas, overwrite_aseg_file=True):
 
 
 @utils.tryit()
-def create_high_level_atlas(subject, high_level_atlas_name='high.level.atlas', base_atlas='aparc.DKTatlas40',
+def create_high_level_atlas(subject, high_level_atlas_name='high.level.atlas', base_atlas='aparc.DKTatlas',
                             overwrite=False):
-    if not utils.both_hemi_files_exist(op.join(SUBJECTS_DIR, subject, 'label', '{hemi}.aparc.DKTatlas40.annot')):
+    if not utils.both_hemi_files_exist(op.join(SUBJECTS_DIR, subject, 'label', '{hemi}.aparc.DKTatlas.annot')):
         fu.create_annotation_file(
             subject, base_atlas, subjects_dir=SUBJECTS_DIR, freesurfer_home=FREESURFER_HOME)
     look = create_labels_names_lookup(subject, base_atlas)
@@ -1627,7 +1627,7 @@ def read_cmd_args(argv=None):
 
     pu.add_common_args(parser)
     args = utils.Bag(au.parse_parser(parser, argv))
-    existing_freesurfer_annotations = ['aparc.DKTatlas40', 'aparc', 'aparc.a2009s']
+    existing_freesurfer_annotations = ['aparc.DKTatlas', 'aparc', 'aparc.a2009s']
     args.necessary_files = {'mri': ['aseg.mgz', 'norm.mgz', 'ribbon.mgz', 'T1.mgz', 'orig.mgz', 'brain.mgz'],
         'surf': ['rh.pial', 'lh.pial', 'rh.inflated', 'lh.inflated', 'lh.curv', 'rh.curv', 'rh.sphere.reg',
                  'lh.sphere.reg', 'rh.sphere', 'lh.sphere', 'lh.white', 'rh.white', 'rh.smoothwm','lh.smoothwm',

--- a/src/preproc/examples/anatomy.py
+++ b/src/preproc/examples/anatomy.py
@@ -41,7 +41,7 @@ def create_annot_from_mad(args):
     remote_subject_dir_template = '/mnt/cashlab/Original Data/MG/{subject}/{subject}_Notes_and_Images/{subject}_SurferOutput'
     for subject in args.subject:
         remote_subject_dir = remote_subject_dir_template.format(subject=subject)
-        if utils.both_hemi_files_exist(op.join(remote_subject_dir, 'label', '{hemi}.aparc.DKTatlas40.annot')):
+        if utils.both_hemi_files_exist(op.join(remote_subject_dir, 'label', '{hemi}.aparc.DKTatlas.annot')):
             print('{} has already both annot files!'.format(subject))
             continue
         args = anat.read_cmd_args(dict(
@@ -52,14 +52,14 @@ def create_annot_from_mad(args):
             ignore_missing=True,
         ))
         pu.run_on_subjects(args, anat.main)
-        if not utils.both_hemi_files_exist(op.join(SUBJECTS_DIR, subject.lower(), 'label', '{hemi}.aparc.DKTatlas40.annot')):
+        if not utils.both_hemi_files_exist(op.join(SUBJECTS_DIR, subject.lower(), 'label', '{hemi}.aparc.DKTatlas.annot')):
             print('Couldn\'t create annot files for {}!'.format(subject))
             continue
         local_annot_fol = utils.make_dir(op.join(SUBJECTS_DIR, 'annot_files', subject.lower()))
         for hemi in utils.HEMIS:
-            local_annot_fname = op.join(SUBJECTS_DIR, subject.lower(), 'label', '{}.aparc.DKTatlas40.annot'.format(hemi))
-            remote_annot_fname = op.join(remote_subject_dir, 'label', '{}.aparc.DKTatlas40.annot'.format(hemi))
-            local_temp_annot_fname = op.join(local_annot_fol, '{}.aparc.DKTatlas40.annot'.format(hemi))
+            local_annot_fname = op.join(SUBJECTS_DIR, subject.lower(), 'label', '{}.aparc.DKTatlas.annot'.format(hemi))
+            remote_annot_fname = op.join(remote_subject_dir, 'label', '{}.aparc.DKTatlas.annot'.format(hemi))
+            local_temp_annot_fname = op.join(local_annot_fol, '{}.aparc.DKTatlas.annot'.format(hemi))
             if not op.isfile(remote_annot_fname):
                 if op.isfile(local_annot_fname):
                     shutil.copyfile(local_annot_fname, local_temp_annot_fname)
@@ -185,7 +185,7 @@ def main():
     import collections
     parser = argparse.ArgumentParser(description='MMVT')
     parser.add_argument('-s', '--subject', help='subject name', required=True, type=au.str_arr_type)
-    parser.add_argument('-a', '--atlas', help='atlas name', required=False, default='aparc.DKTatlas40')
+    parser.add_argument('-a', '--atlas', help='atlas name', required=False, default='aparc.DKTatlas')
     parser.add_argument('-u', '--sftp_username', help='sftp username', required=False, default='npeled')
     parser.add_argument('-d', '--sftp_domain', help='sftp domain', required=False, default='door.nmr.mgh.harvard.edu')
     parser.add_argument('--remote_subject_dir', help='remote_subjects_dir', required=False,

--- a/src/preproc/examples/connectivity.py
+++ b/src/preproc/examples/connectivity.py
@@ -217,7 +217,7 @@ def load_connectivity_results(args):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='MMVT')
     parser.add_argument('-s', '--subject', help='subject name', required=True, type=au.str_arr_type)
-    parser.add_argument('-a', '--atlas', help='atlas name', required=False, default='aparc.DKTatlas40')
+    parser.add_argument('-a', '--atlas', help='atlas name', required=False, default='aparc.DKTatlas')
     parser.add_argument('-f', '--function', help='function name', required=True)
     parser.add_argument('--n_jobs', help='cpu num', required=False, default=-1)
     args = utils.Bag(au.parse_parser(parser))

--- a/src/preproc/examples/eeg.py
+++ b/src/preproc/examples/eeg.py
@@ -52,7 +52,7 @@ if __name__ == '__main__':
     parser.add_argument('-s', '--subject', help='subject name', required=True, type=au.str_arr_type)
     parser.add_argument('-m', '--mri_subject', help='mri subject name', required=False, default=None,
                         type=au.str_arr_type)
-    parser.add_argument('-a', '--atlas', help='atlas name', required=False, default='aparc.DKTatlas40')
+    parser.add_argument('-a', '--atlas', help='atlas name', required=False, default='aparc.DKTatlas')
     parser.add_argument('-f', '--function', help='function name', required=True)
     args = utils.Bag(au.parse_parser(parser))
     if not args.mri_subject:

--- a/src/preproc/examples/fMRI.py
+++ b/src/preproc/examples/fMRI.py
@@ -258,7 +258,7 @@ def get_subjects_files(args):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='MMVT')
     parser.add_argument('-s', '--subject', help='subject name', required=False, type=au.str_arr_type, default='colin27')
-    parser.add_argument('-a', '--atlas', help='atlas name', required=False, default='aparc.DKTatlas40')
+    parser.add_argument('-a', '--atlas', help='atlas name', required=False, default='aparc.DKTatlas')
     parser.add_argument('-u', '--sftp_username', help='sftp username', required=False, default='npeled')
     parser.add_argument('-d', '--sftp_domain', help='sftp domain', required=False, default='door.nmr.mgh.harvard.edu')
     parser.add_argument('--remote_subject_dir', help='remote_subjects_dir', required=False,

--- a/src/preproc/examples/meg.py
+++ b/src/preproc/examples/meg.py
@@ -338,7 +338,7 @@ if __name__ == '__main__':
     parser.add_argument('-s', '--subject', help='subject name', required=True, type=au.str_arr_type)
     parser.add_argument('-m', '--mri_subject', help='mri subject name', required=False, default=None,
                         type=au.str_arr_type)
-    parser.add_argument('-a', '--atlas', help='atlas name', required=False, default='aparc.DKTatlas40')
+    parser.add_argument('-a', '--atlas', help='atlas name', required=False, default='aparc.DKTatlas')
     parser.add_argument('-i', '--inverse_method', help='inverse_method', required=False, default='MNE',
                         type=au.str_arr_type)
     parser.add_argument('-f', '--function', help='function name', required=True)

--- a/src/preproc/meg.py
+++ b/src/preproc/meg.py
@@ -1644,7 +1644,7 @@ def calc_stc_per_condition(events=None, task='', stc_t_min=None, stc_t_max=None,
                            overwrite_stc=False, stc_template='', raw_fname='', epo_fname='', evo_fname='', inv_fname='',
                            fwd_usingMEG=True, fwd_usingEEG=True, apply_on_raw=False, raw=None, epochs=None,
                            modality='meg', calc_stc_for_all=False, calc_stcs_diff=True,
-                           atlas='aparc.DKTatlas40', bands=None, calc_inducde_power_per_label=True,
+                           atlas='aparc.DKTatlas', bands=None, calc_inducde_power_per_label=True,
                            induced_power_normalize_proj=True, n_jobs=6):
     # todo: If the evoked is the raw (no events), we need to seperate it into N events with different ids, to avoid memory error
     # Other options is to use calc_labels_avg_for_rest
@@ -1838,9 +1838,9 @@ def dipoles_fit(dipoles_times, dipoloes_title, evokes=None, noise_cov_fname='', 
         head_to_mri_trans_mat_fname = COR
     evo_fname = get_evo_fname(evo_fname)
     if vol_atlas_fname == '':
-        vol_atlas_fname = op.join(op.join(MMVT_DIR, MRI_SUBJECT, 'freeview', 'aparc.DKTatlas40+aseg.mgz'))
+        vol_atlas_fname = op.join(op.join(MMVT_DIR, MRI_SUBJECT, 'freeview', 'aparc.DKTatlas+aseg.mgz'))
     if vol_atlas_lut_fname == '':
-        vol_atlas_lut_fname = op.join(op.join(MMVT_DIR, MRI_SUBJECT, 'freeview', 'aparc.DKTatlas40ColorLUT.txt'))
+        vol_atlas_lut_fname = op.join(op.join(MMVT_DIR, MRI_SUBJECT, 'freeview', 'aparc.DKTatlasColorLUT.txt'))
 
     if not op.isfile(noise_cov_fname):
         print("The noise covariance cannot be found in {}!".format(NOISE_COV))

--- a/src/setup.py
+++ b/src/setup.py
@@ -14,7 +14,7 @@ BLENDER_WIN_DIR = 'C:\Program Files\Blender Foundation\Blender'
 def copy_resources_files(mmvt_root_dir, overwrite=True, only_verbose=False):
     resource_dir = utils.get_resources_fol()
     utils.make_dir(op.join(op.join(mmvt_root_dir, 'color_maps')))
-    files = ['aparc.DKTatlas40_groups.csv', 'atlas.csv', 'sub_cortical_codes.txt', 'FreeSurferColorLUT.txt',
+    files = ['aparc.DKTatlas_groups.csv', 'atlas.csv', 'sub_cortical_codes.txt', 'FreeSurferColorLUT.txt',
              'empty_subject.blend', 'high_level_atlas.csv']
     cm_files = glob.glob(op.join(resource_dir, 'color_maps', '*.npy'))
     all_files_exist = utils.all([op.isfile(op.join(mmvt_root_dir, file_name)) for file_name in files])

--- a/src/utils/freesurfer_utils.py
+++ b/src/utils/freesurfer_utils.py
@@ -366,7 +366,7 @@ def create_annotation_file(subject, atlas, subjects_dir='', freesurfer_home='', 
     ----------
     subject: subject name
     atlas: One of the three atlases included with freesurfer:
-        Possible values are aparc.DKTatlas40, aparc.a2009s or aparc
+        Possible values are aparc.DKTatlas, aparc.a2009s or aparc
         https://surfer.nmr.mgh.harvard.edu/fswiki/CorticalParcellation
     subjects_dir: subjects dir. If empty, get it from the environ
     freesurfer_home: freesurfer home. If empty, get it from the environ
@@ -380,7 +380,7 @@ def create_annotation_file(subject, atlas, subjects_dir='', freesurfer_home='', 
     '''
     atlas_types = {'aparc': 'curvature.buckner40.filled.desikan_killiany',
                    'aparc.a2009s': 'destrieux.simple.2009-07-28',
-                   'aparc.DKTatlas40': 'DKTatlas40'}
+                   'aparc.DKTatlas': 'DKTatlas'}
     atlas_type = atlas_types[atlas]
     check_env_var('FREESURFER_HOME', freesurfer_home)
     check_env_var('SUBJECTS_DIR', subjects_dir)
@@ -749,7 +749,7 @@ def create_seghead(subject, subjects_dir=None, print_only=False, **kargs):
 
 
 def is_fs_atlas(atlas):
-    return atlas in ['aparc.DKTatlas40', 'aparc', 'aparc.a2009s']
+    return atlas in ['aparc.DKTatlas', 'aparc', 'aparc.a2009s']
 
 
 def read_surface(subject, subjects_dir, surf_type='pial'):

--- a/src/utils/preproc_utils.py
+++ b/src/utils/preproc_utils.py
@@ -172,7 +172,7 @@ def add_default_args(args, default_args):
 
 def add_common_args(parser):
     parser.add_argument('-s', '--subject', help='subject name', required=True, type=au.str_arr_type)
-    parser.add_argument('-a', '--atlas', help='atlas name', required=False, default='aparc.DKTatlas40')
+    parser.add_argument('-a', '--atlas', help='atlas name', required=False, default='aparc.DKTatlas')
     parser.add_argument('-f', '--function', help='function name', required=False, default='all', type=au.str_arr_type)
     parser.add_argument('--exclude', help='functions not to run', required=False, default='', type=au.str_arr_type)
     parser.add_argument('--n_jobs', help='cpu num', required=False, default=-1)

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -924,6 +924,12 @@ def prepare_subject_folder(necessary_files, subject, remote_subject_dir, local_s
                     local_fname = op.join(local_subject_dir, fol, file_name)
                     remote_fname = op.join(remote_subject_dir, fol, file_name)
                     local_files = glob.glob(local_fname)
+                    # fs53 DKT atlas backward compatibility fix
+                    if 'DKTatlas' in file_name and not op.isfile(remote_fname):
+                        fs53_fname = file_name.replace('DKTatlas', 'DKTatlas40')
+                        fs53_remote_fname = op.join(remote_subject_dir, fol, fs53_fname)
+                        if op.isfile(fs53_remote_fname):
+                            shutil.copyfile(fs53_remote_fname, remote_fname)
                     if len(local_files) == 0 or overwrite_files:
                         remote_files = glob.glob(remote_fname)
                         if len(remote_files) > 0:


### PR DESCRIPTION
In Freesurfer 6, DKTatlas40 is renamed to DKTatlas. The only time I run into issues is with src.preproc.anatomy and I tested that that script runs fine, but since we haven't made tests for all the examples yet, I am not sure if all the examples etc. still run. If you have time to run through all the examples and make sure they still work, this would be a good edit so that MMVT is on track with the fs6 defaults. #180 