### PR TITLE
Smooth helmet

### DIFF
--- a/src/mmvt_addon/coloring_panel.py
+++ b/src/mmvt_addon/coloring_panel.py
@@ -1029,7 +1029,7 @@ def set_activity_values(cur_obj, values):
 # @mu.timeit
 def activity_map_obj_coloring(cur_obj, vert_values, lookup=None, threshold=0, override_current_mat=True, data_min=None,
                               colors_ratio=None, use_abs=None, bigger_or_equall=False, save_prev_colors=False,
-                              coloring_layer='Col', check_valid_verts=True, uv_size = 100):
+                              coloring_layer='Col', check_valid_verts=True, uv_size = 1000):
     if isinstance(cur_obj, str):
         cur_obj = bpy.data.objects[cur_obj]
     if lookup is None:
@@ -1094,10 +1094,10 @@ def uv_map_obj_coloring(cur_obj, mesh, valid_verts, vert_values, uv_size):
             sigma = min([(this_uv - other_uv).magnitude
                          for other_uv in all_uvs if
                          (this_uv - other_uv).magnitude > 1e-4])
-            f = cu.symGauss2D(x0, y0, sigma)
+            f = cu.sym_gauss_2D(x0, y0, sigma)
             for i, x in enumerate(np.linspace(0, 1, uv_size)):
                 for j, y in enumerate(np.linspace(0, 1, uv_size)):
-                    im[i, j] += f(x, y)/f(x0, y0)*vert_values[this_loop.vertex_index]
+                    im[j, i] += f(x, y)/f(x0, y0)*vert_values[this_loop.vertex_index]
 
     #if not 'ActivityMap' in bpy.data.materials:
     #    bpy.data.materials.new('ActivityMap')
@@ -1107,6 +1107,7 @@ def uv_map_obj_coloring(cur_obj, mesh, valid_verts, vert_values, uv_size):
     cTex = bpy.data.textures['ActivityTexture']
     cTex.image = cu.get_activity_map_im(im, cmap='jet')  # _addon().get_cm())
     cur_obj.active_material.active_texture = cTex #probably delete, needs to be added node style
+
 
 def vertex_object_coloring(cur_obj, mesh, coloring_layer, valid_verts, verts_colors, vert_values,
                            lookup, override_current_mat, save_prev_colors, colors_picked_from_cm):
@@ -1130,6 +1131,7 @@ def vertex_object_coloring(cur_obj, mesh, coloring_layer, valid_verts, verts_col
     else:
         verts_lookup_loop_coloring(
             valid_verts, lookup, vcol_layer, lambda vert:vert_values[vert, 1:], cur_obj.name, save_prev_colors)
+
 
 def verts_lookup_loop_coloring(valid_verts, lookup, vcol_layer, colors_func, cur_obj_name, save_prev_colors=False):
     if save_prev_colors:

--- a/src/mmvt_addon/coloring_panel.py
+++ b/src/mmvt_addon/coloring_panel.py
@@ -1086,6 +1086,7 @@ def uv_map_obj_coloring(cur_obj, mesh, valid_verts, vert_values, uv_size):
     all_uvs = [mesh.uv_layers['activity_map'].data[loop.index].uv
                for loop in mesh.loops]
 
+    im = np.zeros((uv_size, uv_size))
     for this_loop in mesh.loops:
         if this_loop.vertex_index in valid_verts:
             this_uv = mesh.uv_layers.active.data[this_loop.index].uv

--- a/src/mmvt_addon/coloring_panel.py
+++ b/src/mmvt_addon/coloring_panel.py
@@ -1064,6 +1064,13 @@ def activity_map_obj_coloring(cur_obj, vert_values, lookup=None, threshold=0, ov
     #check if our mesh already has Vertex Colors, and if not add some... (first we need to make sure it's the active object)
     scn.objects.active = cur_obj
     cur_obj.select = True
+    if len(mesh.vertices) < 1e3:
+        uv_map_obj_coloring(cur_obj, mesh, valid_verts, vert_values, uv_size)
+    else:
+        vertex_object_coloring(cur_obj, mesh, coloring_layer, valid_verts, verts_colors, vert_values,
+                               lookup, override_current_mat, save_prev_colors, colors_picked_from_cm)
+
+def uv_map_obj_coloring(cur_obj, mesh, valid_verts, vert_values, uv_size):
     if not 'activity_map' in mesh.uv_textures:
         mesh.uv_textures.new('activity_map')
     mesh.uv_textures['activity_map'].active_render = True
@@ -1101,7 +1108,8 @@ def activity_map_obj_coloring(cur_obj, vert_values, lookup=None, threshold=0, ov
     cTex.image = cu.get_activity_map_im(im, cmap='jet')  # _addon().get_cm())
     cur_obj.active_material.active_texture = cTex #probably delete, needs to be added node style
 
-    '''
+def vertex_object_coloring(cur_obj, mesh, coloring_layer, valid_verts, verts_colors, vert_values,
+                           lookup, override_current_mat, save_prev_colors, colors_picked_from_cm):
     if override_current_mat:
         recreate_coloring_layers(mesh, coloring_layer)
         # vcol_layer = mesh.vertex_colors["Col"]
@@ -1122,7 +1130,6 @@ def activity_map_obj_coloring(cur_obj, vert_values, lookup=None, threshold=0, ov
     else:
         verts_lookup_loop_coloring(
             valid_verts, lookup, vcol_layer, lambda vert:vert_values[vert, 1:], cur_obj.name, save_prev_colors)
-    '''
 
 def verts_lookup_loop_coloring(valid_verts, lookup, vcol_layer, colors_func, cur_obj_name, save_prev_colors=False):
     if save_prev_colors:

--- a/src/mmvt_addon/coloring_panel.py
+++ b/src/mmvt_addon/coloring_panel.py
@@ -1092,15 +1092,14 @@ def activity_map_obj_coloring(cur_obj, vert_values, lookup=None, threshold=0, ov
                 for j, y in enumerate(np.linspace(0, 1, uv_size)):
                     im[i, j] += f(x, y)/f(x0, y0)*vert_values[this_loop.vertex_index]
 
-    if not 'ActivityMap' in bpy.data.materials:
-        bpy.data.materials.new('ActivityMap')
-    mat = bpy.data.materials['ActivityMap']
+    #if not 'ActivityMap' in bpy.data.materials:
+    #    bpy.data.materials.new('ActivityMap')
+    #mat = bpy.data.materials['ActivityMap']
     if not 'ActivityTexture' in bpy.data.textures:
         bpy.data.textures.new('ActivityTexture', type='IMAGE')
     cTex = bpy.data.textures['ActivityTexture']
     cTex.image = cu.get_activity_map_im(im, cmap='jet')  # _addon().get_cm())
-    mat.active_texture = cTex
-    #cur_obj.active_material = mat
+    cur_obj.active_material.active_texture = cTex #probably delete, needs to be added node style
 
     '''
     if override_current_mat:

--- a/src/mmvt_addon/coloring_panel.py
+++ b/src/mmvt_addon/coloring_panel.py
@@ -1086,7 +1086,6 @@ def uv_map_obj_coloring(cur_obj, mesh, valid_verts, vert_values, uv_size):
     all_uvs = [mesh.uv_layers['activity_map'].data[loop.index].uv
                for loop in mesh.loops]
 
-    im = np.zeros((uv_size, uv_size))
     for this_loop in mesh.loops:
         if this_loop.vertex_index in valid_verts:
             this_uv = mesh.uv_layers.active.data[this_loop.index].uv
@@ -1097,7 +1096,7 @@ def uv_map_obj_coloring(cur_obj, mesh, valid_verts, vert_values, uv_size):
             f = cu.sym_gauss_2D(x0, y0, sigma)
             for i, x in enumerate(np.linspace(0, 1, uv_size)):
                 for j, y in enumerate(np.linspace(0, 1, uv_size)):
-                    im[j, i] += f(x, y)/f(x0, y0)*vert_values[this_loop.vertex_index]
+                    im[-j-1,i] += f(x, y)/f(x0, y0)*vert_values[this_loop.vertex_index]
 
     #if not 'ActivityMap' in bpy.data.materials:
     #    bpy.data.materials.new('ActivityMap')

--- a/src/mmvt_addon/coloring_panel.py
+++ b/src/mmvt_addon/coloring_panel.py
@@ -1029,7 +1029,7 @@ def set_activity_values(cur_obj, values):
 # @mu.timeit
 def activity_map_obj_coloring(cur_obj, vert_values, lookup=None, threshold=0, override_current_mat=True, data_min=None,
                               colors_ratio=None, use_abs=None, bigger_or_equall=False, save_prev_colors=False,
-                              coloring_layer='Col', check_valid_verts=True, uv_size = 1000):
+                              coloring_layer='Col', check_valid_verts=True, uv_size = 200):
     if isinstance(cur_obj, str):
         cur_obj = bpy.data.objects[cur_obj]
     if lookup is None:

--- a/src/mmvt_addon/coloring_panel.py
+++ b/src/mmvt_addon/coloring_panel.py
@@ -1073,7 +1073,7 @@ def activity_map_obj_coloring(cur_obj, vert_values, lookup=None, threshold=0, ov
     # Get the active mesh
     mesh = cur_obj.data
     # Project to UV Map
-    bpy.ops.uv.smart_project()
+    bpy.ops.uv.unwrap() #no cuts-- helmet-> no discontinuities
 
     bpy.ops.object.mode_set(mode='OBJECT')
     all_uvs = [mesh.uv_layers['activity_map'].data[loop.index].uv
@@ -1100,7 +1100,7 @@ def activity_map_obj_coloring(cur_obj, vert_values, lookup=None, threshold=0, ov
     cTex = bpy.data.textures['ActivityTexture']
     cTex.image = cu.get_activity_map_im(im, cmap='jet')  # _addon().get_cm())
     mat.active_texture = cTex
-    cur_obj.active_material = mat
+    #cur_obj.active_material = mat
 
     '''
     if override_current_mat:

--- a/src/mmvt_addon/colors_utils.py
+++ b/src/mmvt_addon/colors_utils.py
@@ -300,7 +300,6 @@ def get_activity_map_im(im,cmap):
     ax.set_axis_off()
     fig.add_axes(ax)
     ax.imshow(im, cmap=cmap)
-    ax.invert_xaxis()
     ax.invert_yaxis()
     map_dir = op.join(os.getcwd(), 'examples')
     fname = op.join(map_dir, 'activity_map.png')

--- a/src/mmvt_addon/colors_utils.py
+++ b/src/mmvt_addon/colors_utils.py
@@ -2,7 +2,12 @@ import re
 from collections import OrderedDict
 import numpy as np
 from itertools import cycle
-import matplotlib.pyplot as plt
+try:
+    import matplotlib
+    matplotlib.use('Agg')
+    import matplotlib.pyplot as plt
+except:
+    print('Unable to import matplotlib')
 import os
 import os.path as op
 import math
@@ -283,8 +288,10 @@ def normalize_hex(hex_value):
         hex_digits = u''.join(2 * s for s in hex_digits)
     return u'#{}'.format(hex_digits.lower())
 
-def symGauss2D(x0,y0,sigma):
+
+def sym_gauss_2D(x0,y0,sigma):
     return lambda x,y: (1./(2*math.pi*sigma**2))*math.exp(-((x-x0)**2+(y-y0)**2)/(2*sigma**2))
+
 
 def get_activity_map_im(im,cmap):
     fig = plt.figure(frameon=False)
@@ -293,7 +300,7 @@ def get_activity_map_im(im,cmap):
     ax.set_axis_off()
     fig.add_axes(ax)
     ax.imshow(im, cmap=cmap)
-    #x.invert_xaxis()
+    ax.invert_xaxis()
     ax.invert_yaxis()
     map_dir = op.join(os.getcwd(), 'examples')
     fname = op.join(map_dir, 'activity_map.png')

--- a/src/mmvt_addon/colors_utils.py
+++ b/src/mmvt_addon/colors_utils.py
@@ -293,15 +293,13 @@ def get_activity_map_im(im,cmap):
     ax.set_axis_off()
     fig.add_axes(ax)
     ax.imshow(im, cmap=cmap)
-    tmp_dir = op.join(os.getcwd(), 'tmp')
-    if not op.isdir(tmp_dir):
-        os.makedirs(tmp_dir)
-    fname = op.join(tmp_dir, 'activity_map.png')
+    map_dir = op.join(os.getcwd(), 'examples')
+    fname = op.join(map_dir, 'activity_map.png')
+    if op.isfile(fname):
+        os.remove(fname)
     fig.savefig(fname)
     plt.close(fig)
     img = bpy.data.images.load(fname)
-    os.remove(fname)h
-    os.remove(tmp_dir)
     return img
 
 

--- a/src/mmvt_addon/colors_utils.py
+++ b/src/mmvt_addon/colors_utils.py
@@ -300,6 +300,7 @@ def get_activity_map_im(im,cmap):
     ax.set_axis_off()
     fig.add_axes(ax)
     ax.imshow(im, cmap=cmap)
+    ax.invert_yaxis()
     map_dir = op.join(os.getcwd(), 'examples')
     fname = op.join(map_dir, 'activity_map.png')
     if op.isfile(fname):

--- a/src/mmvt_addon/colors_utils.py
+++ b/src/mmvt_addon/colors_utils.py
@@ -289,26 +289,3 @@ def normalize_hex(hex_value):
     return u'#{}'.format(hex_digits.lower())
 
 
-def sym_gauss_2D(x0,y0,sigma):
-    return lambda x,y: (1./(2*math.pi*sigma**2))*math.exp(-((x-x0)**2+(y-y0)**2)/(2*sigma**2))
-
-
-def get_activity_map_im(im,cmap):
-    fig = plt.figure(frameon=False)
-    fig.set_size_inches(6, 6)
-    ax = plt.Axes(fig, [0., 0., 1., 1.])
-    ax.set_axis_off()
-    fig.add_axes(ax)
-    ax.imshow(im, cmap=cmap)
-    ax.invert_yaxis()
-    map_dir = op.join(os.getcwd(), 'examples')
-    fname = op.join(map_dir, 'activity_map.png')
-    if op.isfile(fname):
-        os.remove(fname)
-    print('Saving UV map to {}'.format(fname))
-    fig.savefig(fname)
-    plt.close(fig)
-    img = bpy.data.images.load(fname)
-    return img
-
-

--- a/src/mmvt_addon/colors_utils.py
+++ b/src/mmvt_addon/colors_utils.py
@@ -286,13 +286,13 @@ def normalize_hex(hex_value):
 def symGauss2D(x0,y0,sigma):
     return lambda x,y: (1./(2*math.pi*sigma**2))*math.exp(-((x-x0)**2+(y-y0)**2)/(2*sigma**2))
 
-def save_activity_map_im(im):
+def get_activity_map_im(im,cmap):
     fig = plt.figure(frameon=False)
     fig.set_size_inches(6, 6)
     ax = plt.Axes(fig, [0., 0., 1., 1.])
     ax.set_axis_off()
     fig.add_axes(ax)
-    ax.imshow(im, cmap='ocean')
+    ax.imshow(im, cmap=cmap)
     tmp_dir = op.join(os.getcwd(), 'tmp')
     if not op.isdir(tmp_dir):
         os.makedirs(tmp_dir)

--- a/src/mmvt_addon/colors_utils.py
+++ b/src/mmvt_addon/colors_utils.py
@@ -300,6 +300,8 @@ def get_activity_map_im(im,cmap):
     fig.savefig(fname)
     plt.close(fig)
     img = bpy.data.images.load(fname)
+    os.remove(fname)h
+    os.remove(tmp_dir)
     return img
 
 

--- a/src/mmvt_addon/colors_utils.py
+++ b/src/mmvt_addon/colors_utils.py
@@ -2,6 +2,11 @@ import re
 from collections import OrderedDict
 import numpy as np
 from itertools import cycle
+import matplotlib.pyplot as plt
+import os
+import os.path as op
+import math
+import bpy
 # Light version of webcolors
 
 # http://stackoverflow.com/a/4382138/1060738
@@ -277,3 +282,24 @@ def normalize_hex(hex_value):
     if len(hex_digits) == 3:
         hex_digits = u''.join(2 * s for s in hex_digits)
     return u'#{}'.format(hex_digits.lower())
+
+def symGauss2D(x0,y0,sigma):
+    return lambda x,y: (1./(2*math.pi*sigma**2))*math.exp(-((x-x0)**2+(y-y0)**2)/(2*sigma**2))
+
+def save_activity_map_im(im):
+    fig = plt.figure(frameon=False)
+    fig.set_size_inches(6, 6)
+    ax = plt.Axes(fig, [0., 0., 1., 1.])
+    ax.set_axis_off()
+    fig.add_axes(ax)
+    ax.imshow(im, cmap='ocean')
+    tmp_dir = op.join(os.getcwd(), 'tmp')
+    if not op.isdir(tmp_dir):
+        os.makedirs(tmp_dir)
+    fname = op.join(tmp_dir, 'activity_map.png')
+    fig.savefig(fname)
+    plt.close(fig)
+    img = bpy.data.images.load(fname)
+    return img
+
+

--- a/src/mmvt_addon/colors_utils.py
+++ b/src/mmvt_addon/colors_utils.py
@@ -293,10 +293,13 @@ def get_activity_map_im(im,cmap):
     ax.set_axis_off()
     fig.add_axes(ax)
     ax.imshow(im, cmap=cmap)
+    #x.invert_xaxis()
+    ax.invert_yaxis()
     map_dir = op.join(os.getcwd(), 'examples')
     fname = op.join(map_dir, 'activity_map.png')
     if op.isfile(fname):
         os.remove(fname)
+    print('Saving UV map to {}'.format(fname))
     fig.savefig(fname)
     plt.close(fig)
     img = bpy.data.images.load(fname)

--- a/src/mmvt_addon/colors_utils.py
+++ b/src/mmvt_addon/colors_utils.py
@@ -300,7 +300,6 @@ def get_activity_map_im(im,cmap):
     ax.set_axis_off()
     fig.add_axes(ax)
     ax.imshow(im, cmap=cmap)
-    ax.invert_yaxis()
     map_dir = op.join(os.getcwd(), 'examples')
     fname = op.join(map_dir, 'activity_map.png')
     if op.isfile(fname):


### PR DESCRIPTION
Uses a UV map to create MEG helmet image. This is done by unwrapping the helmet in 2D UV space, then making an image where every vertex above threshold adds a 2D symmetric Gaussian with a standard deviation equal to it's nearest neighbor.

To do:

1. The UV map causes stretching so even though the size of the Guassian is corrected by the nearest neighbor, the map would be more accurate if the Guassian was not symmetrical if neighbors in one direction were farther. (This might be okay as is, this would be a pretty involved fix).

2. I was able to display the texture using the node display:

<img width="456" alt="screen shot 2018-11-03 at 9 14 07 pm" src="https://user-images.githubusercontent.com/13473576/47964742-1026ae80-e00c-11e8-8353-a7c6a98f6109.png">

This needs to be added to the default MEG helmet or incorporated in another way which would probably be in src/mmvt_addon/coloring_pannel around line 1102.

3. Even with the node display as it was, the image is only visible in material or rendered view, not in solid view. When Plot MEG Helmet is called it could switch to rendered or maybe someone knows how to have the image appear on the solid.

![default_24 jpeg_1](https://user-images.githubusercontent.com/13473576/47964849-5d575000-e00d-11e8-9505-dd8bb7a383ca.jpeg)
![default_24 jpeg_0](https://user-images.githubusercontent.com/13473576/47964856-74963d80-e00d-11e8-847f-8068bd1c6971.jpeg)

